### PR TITLE
chore: yarn upgrade dependencies requiring intervention

### DIFF
--- a/packages/aws-cdk-lib/package.json
+++ b/packages/aws-cdk-lib/package.json
@@ -117,7 +117,7 @@
     "mime-types"
   ],
   "dependencies": {
-    "@aws-cdk/asset-awscli-v1": "2.2.282",
+    "@aws-cdk/asset-awscli-v1": "2.2.292",
     "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
     "@aws-cdk/cloud-assembly-api": "^2.2.6",
     "@aws-cdk/cloud-assembly-schema": "^54.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
   resolved "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz#4cdb6254da7962b07473ff5c335f3da485d94d71"
   integrity sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==
 
-"@aws-cdk/asset-awscli-v1@2.2.282":
-  version "2.2.282"
-  resolved "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz#3d25c0fe14ae9db8dfe2d1214cec6b7e3f8880b3"
-  integrity sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==
+"@aws-cdk/asset-awscli-v1@2.2.292":
+  version "2.2.292"
+  resolved "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz#caa029bbe15199606f39877c68bf5880b1f59869"
+  integrity sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==
 
 "@aws-cdk/asset-node-proxy-agent-v6@^2.1.2":
   version "2.1.2"


### PR DESCRIPTION
Ran npm-check-updates and yarn upgrade for the following dependencies:
```
@aws-cdk/asset-awscli-v1
```
Checkout this branch and run integration tests locally to update snapshots.
```
(cd packages/@aws-cdk-testing/framework-integ && yarn integ --update-on-failed)
```
See https://www.npmjs.com/package/@aws-cdk/integ-runner for more integ runner options.